### PR TITLE
Added missing dir pin configuration

### DIFF
--- a/drivers/tmc2209/src/tmc2209.c
+++ b/drivers/tmc2209/src/tmc2209.c
@@ -52,6 +52,7 @@ static int tmc2209_init(const struct device *dev) {
 	// disable stepper
 	//gpio_pin_configure_dt(&cfg->en, GPIO_OUTPUT_INACTIVE);
 	gpio_pin_configure_dt(&cfg->en, GPIO_OUTPUT_ACTIVE);
+	gpio_pin_configure_dt(&cfg->dir, GPIO_OUTPUT_ACTIVE);
 
 	LOG_DBG("tmc2209_init done");
 


### PR DESCRIPTION
Hello, I am using a tm2209 and found out that the direction was not working. Looks that the configuration for dir pin was missing so I added it along with the enable pin. With this little change it is working.